### PR TITLE
Couple of fixes to ProjectInitializer

### DIFF
--- a/Exporter/PressPlay.FFWD.Unity/Editor/ExportSceneWizard.cs
+++ b/Exporter/PressPlay.FFWD.Unity/Editor/ExportSceneWizard.cs
@@ -362,9 +362,16 @@ public class ExportSceneWizard : ScriptableWizard
 
         private void FindAllUnityScripts()
         {
-            foreach (string file in Directory.GetFiles(Path.Combine(Application.dataPath, config.unityScriptDir), "*.cs", SearchOption.AllDirectories))
+            if (Directory.Exists(Path.Combine(Application.dataPath, config.unityScriptDir)))
             {
-                unityScriptFiles[Path.GetFileNameWithoutExtension(file)] = file;
+                foreach (string file in Directory.GetFiles(Path.Combine(Application.dataPath, config.unityScriptDir), "*.cs", SearchOption.AllDirectories))
+                {
+                    unityScriptFiles[Path.GetFileNameWithoutExtension(file)] = file;
+                }
+            }
+            else
+            {
+                Debug.LogError("Unity scripts folder '" + config.unityScriptDir + "' not found.");
             }
         }
 

--- a/Tools/ProjectInitializer/ProjectInitializer/Program.cs
+++ b/Tools/ProjectInitializer/ProjectInitializer/Program.cs
@@ -85,10 +85,14 @@ namespace ProjectInitializer
                 }
                 if (!ignoreFileTypes.Contains(Path.GetExtension(newFileName)))
                 {
-                    File.Copy(item, Path.Combine(newDir, newFileName));
+                    string completeNewName = Path.Combine(newDir, newFileName);
+                    if (!item.Equals(completeNewName, StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        File.Copy(item, completeNewName);
+                    }
                     if (fixFileContentsOfFileTypes.Contains(Path.GetExtension(newFileName)))
                     {
-                        FixFileContents(Path.Combine(newDir, newFileName));                       
+                        FixFileContents(completeNewName);
                     }
                 }
             }

--- a/Tools/ProjectInitializer/ProjectInitializer/Program.cs
+++ b/Tools/ProjectInitializer/ProjectInitializer/Program.cs
@@ -101,9 +101,9 @@ namespace ProjectInitializer
 
         private void FixFileContents(string newFileName)
         {
-            string text = File.ReadAllText(newFileName);
+            string text = File.ReadAllText(newFileName, Encoding.UTF8);
             text = text.Replace(templateName, projectName);
-            File.WriteAllText(newFileName, text);
+            File.WriteAllText(newFileName, text, Encoding.UTF8);
         }
     }
 }


### PR DESCRIPTION
 Hi there.

 I fixed a couple of issues I found in ProjectInitializer:
- In on of my PCs, after renaming FFWD.Template.sln to newprojectname.sln, EnumerateFiles would return the new file, which would be copied over itself, with the corresponding exception. I added a check to make sure files were only copied if the names differ.
- After renaming, double clicking in the new .sln file would not launch a new Visual Studio instance. That's because the new file contents are written without setting an encoding, and were thus plain ASCII. Visual Studio only seems to autorun with UTF8 files. My patch reads and writes files to be fixed using UTF8 encoding, so Visual Studio uses them as expected.
  
  I hope this helps future users of this project get started.
  
  Thanks for the effort and good luck,
  Elideb
