### PR TITLE
Implemented public float grayscale

### DIFF
--- a/Framework/PressPlay.FFWD/Color.cs
+++ b/Framework/PressPlay.FFWD/Color.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace PressPlay.FFWD
 {
@@ -57,12 +57,11 @@ namespace PressPlay.FFWD
             }
         }
 
-        public float greyscale
+        public float grayscale
         {
             get
             {
-                // TODO: Implement this
-                throw new NotImplementedException("Not implemented");
+                return (float)((0.2126*r) + (0.7152*g) + (0.0722*b));
             }
         }
 


### PR DESCRIPTION
Changed greyscale to grayscale and implemented grayscale.
Grayscale and luma, both represents brightness in an image. 
So we are using luma = 0.2126_Red + 0.7152_Green + 0.0722*Blue

R. W. G. Hunt, M. R. Pointer 2011, Measuring Colour 4th Edition
